### PR TITLE
Update material.rstheme

### DIFF
--- a/src/cpp/session/resources/themes/material.rstheme
+++ b/src/cpp/session/resources/themes/material.rstheme
@@ -45,11 +45,11 @@
 }
 
 .ace_gutter-active-line {
-  background-color: #263238
+  background-color: #353637
 }
 
 .ace_marker-layer .ace_selected-word {
-  border: 1px solid #263238
+  border: 1px solid rgba(90, 100, 126, 0.88)
 }
 
 .ace_invisible {


### PR DESCRIPTION


### Intent

the current material theme has no selected word or text highlighting (or rather, they were set to the same as the background colour). 

### Approach

I just stole the settings from idle_fingers.rstheme.

### Automated Tests

No tests. Small style change which works fine on my pc. 

### QA Notes

n/a

### Documentation

none

### Checklist

- [ no] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ yes] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ no] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ not tested] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

Done.
